### PR TITLE
feat: add paging options for issues

### DIFF
--- a/app/i/[issueNo]/page.tsx
+++ b/app/i/[issueNo]/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from "next/navigation"
 import { SquarePen } from "lucide-react"
 import { Link } from "next-view-transitions"
 
-import { getAllIssues, getIssueByNo } from "@/lib/github"
+import { getIssueByNo, getIssues } from "@/lib/github"
 import { Mdx } from "@/components/mdx-remote"
 
 interface PageParams {
@@ -10,7 +10,7 @@ interface PageParams {
 }
 
 export async function generateStaticParams(): Promise<PageParams[]> {
-  const issues = await getAllIssues()
+  const { issues } = await getIssues()
 
   return issues.map((issue) => ({
     issueNo: issue.number.toString(),

--- a/app/p/page.tsx
+++ b/app/p/page.tsx
@@ -1,12 +1,12 @@
 import { notFound } from "next/navigation"
 import { Link } from "next-view-transitions"
 
-import { config, getAllIssues } from "@/lib/github"
+import { config, getIssues } from "@/lib/github"
 import { cn } from "@/lib/utils"
 import { buttonVariants } from "@/components/ui/button"
 
 export default async function Page() {
-  const issues = await getAllIssues()
+  const { issues } = await getIssues()
 
   if (!issues) {
     return notFound()

--- a/components/mdx-remote.tsx
+++ b/components/mdx-remote.tsx
@@ -114,7 +114,7 @@ const components = {
   th: ({ className, ...props }: React.HTMLAttributes<HTMLTableCellElement>) => (
     <th
       className={cn(
-        "px-4 py-2 text-left font-bold [&[align=center]]:text-center [&[align=right]]:text-right",
+        "px-4 py-2 text-left font-bold text-nowrap [&[align=center]]:text-center [&[align=right]]:text-right",
         className
       )}
       {...props}

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -26,7 +26,12 @@ const octokit = new Octokit({
   auth,
 })
 
-export async function getAllIssues() {
+interface GetIssuesParams {
+  page?: number
+  per_page?: number
+}
+
+export async function getIssues({ page = 1, per_page = 100 }: GetIssuesParams = {}) {
   try {
     const response = await octokit.rest.issues.listForRepo({
       owner,
@@ -34,9 +39,10 @@ export async function getAllIssues() {
       state: "open",
       sort: "created",
       direction: "desc",
-      per_page: 100,
       // TODO: config로 분리
       labels: "learn",
+      page,
+      per_page,
     })
 
     const issues = response.data.map((issue) => ({
@@ -53,11 +59,39 @@ export async function getAllIssues() {
       },
     }))
 
-    return issues.map((issue, index) => ({
-      ...issue,
-      nextIssueNo: issues[index - 1]?.number,
-      prevIssueNo: issues[index + 1]?.number,
-    }))
+    const linkHeader = response.headers.link
+    let lastPage = 0
+
+    if (linkHeader) {
+      const links = linkHeader.split(", ")
+      links.forEach((link) => {
+        const [url, rel] = link.split("; ")
+        const pageMatch = url.match(/&page=(\d+)/)
+        if (pageMatch) {
+          const page = parseInt(pageMatch[1], 10)
+          if (rel === 'rel="last"') {
+            lastPage = page
+          }
+        }
+      })
+    }
+
+    lastPage = lastPage === 0 ? page : lastPage
+
+    const hasNextPage = page < lastPage
+
+    return {
+      issues: issues.map((issue, index) => ({
+        ...issue,
+        nextIssueNo: issues[index - 1]?.number,
+        prevIssueNo: issues[index + 1]?.number,
+      })),
+      pageInfo: {
+        currentPage: page,
+        hasNextPage,
+        lastPage,
+      },
+    }
   } catch (error) {
     console.error("failed to fetch(getAllIssueId): ", error)
     throw error
@@ -99,79 +133,6 @@ export async function getIssueByNo(issueNo: number) {
     }
   } catch (error) {
     console.error("failed to fetch(fetchIssue): ", error)
-    throw error
-  }
-}
-
-// FIXME: remove me for not used
-export async function getIssuePagination(pageNo = 1, pageRow = 20) {
-  try {
-    const response = await octokit.rest.issues.listForRepo({
-      owner,
-      repo,
-      per_page: pageRow,
-      page: pageNo,
-      state: "open",
-      sort: "created",
-      direction: "desc",
-      // TODO: config로 분리
-      labels: "learn",
-    })
-
-    const issues = response.data.map((issue) => ({
-      id: issue.node_id,
-      number: issue.number,
-      title: issue.title,
-      createdAt: issue.created_at,
-      updatedAt: issue.updated_at,
-      labels: {
-        nodes: issue.labels.map((label) => ({
-          id: typeof label === "string" ? label : label.node_id,
-          name: typeof label === "string" ? label : label.name,
-          color: typeof label === "string" ? "" : label.color,
-        })),
-      },
-      author: {
-        login: issue.user?.login,
-        avatarUrl: issue.user?.avatar_url,
-      },
-      comments: {
-        totalCount: issue.comments,
-      },
-      issueUrl: issue.html_url,
-    }))
-
-    const linkHeader = response.headers.link
-    let lastPage = 0
-
-    if (linkHeader) {
-      const links = linkHeader.split(", ")
-      links.forEach((link) => {
-        const [url, rel] = link.split("; ")
-        const pageMatch = url.match(/&page=(\d+)/)
-        if (pageMatch) {
-          const page = parseInt(pageMatch[1], 10)
-          if (rel === 'rel="last"') {
-            lastPage = page
-          }
-        }
-      })
-    }
-
-    lastPage = lastPage === 0 ? pageNo : lastPage
-
-    const hasNextPage = pageNo < lastPage
-
-    return {
-      issues,
-      pageInfo: {
-        hasNextPage,
-        currentPage: pageNo,
-        lastPage,
-      },
-    }
-  } catch (error) {
-    console.error("failed to fetch(fetchIssues): ", error)
     throw error
   }
 }


### PR DESCRIPTION
add `fetch` paging options for github issues api in a repository.

---

## Copilot summary

This pull request includes several changes to improve the issue fetching logic and update the usage of the issue fetching functions across various files. The changes involve replacing the `getAllIssues` function with a more flexible `getIssues` function that supports pagination, and updating the components to use this new function.

### Updates to issue fetching logic:

* [`lib/github.ts`](diffhunk://#diff-3e9b3fd031e8f78b9b5455fa3ed5f310e1e2ba9a4127b97b9e6715fed9852eefL29-R45): Replaced `getAllIssues` with `getIssues`, which includes support for pagination and returns additional page information. Removed the unused `getIssuePagination` function. [[1]](diffhunk://#diff-3e9b3fd031e8f78b9b5455fa3ed5f310e1e2ba9a4127b97b9e6715fed9852eefL29-R45) [[2]](diffhunk://#diff-3e9b3fd031e8f78b9b5455fa3ed5f310e1e2ba9a4127b97b9e6715fed9852eefL56-R94) [[3]](diffhunk://#diff-3e9b3fd031e8f78b9b5455fa3ed5f310e1e2ba9a4127b97b9e6715fed9852eefL106-L178)

### Updates to components using issue fetching:

* `app/i/[issueNo]/page.tsx`: Updated to use the new `getIssues` function instead of `getAllIssues`. ([app/i/[issueNo]/page.tsxL5-R13](diffhunk://#diff-de0018f2fc79607110a9182e2f68e9f58d86877b61fe4c1f8534e200ab6574dbL5-R13))
* [`app/p/page.tsx`](diffhunk://#diff-9ac6c2266c0f9b134ba6980df45372c6bf01184b7776b6eaf7b78d9f07278c38L4-R9): Updated to use the new `getIssues` function instead of `getAllIssues`.

### Minor UI update:

* [`components/mdx-remote.tsx`](diffhunk://#diff-0ab4695c4077e1b795f0b2a505e7dbf17bd721f566643cbb265c26f2a565f186L117-R117): Added `text-nowrap` class to table header cells to prevent text wrapping.



