### PR TITLE
feat: update Claude workflows to ensure responses are always in Korean

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -46,6 +46,7 @@ jobs:
             - Performance considerations
             - Security concerns
             - Test coverage
+            - Always Response in Korean
 
             Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
 
@@ -54,4 +55,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -47,4 +47,5 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-
+          claude_args: |
+            --system-prompt "Always Response in Korean"


### PR DESCRIPTION
- Added a requirement for the Claude Code Review workflow to always respond in Korean.
- Updated the Claude PR Assistant workflow to include a system prompt for consistent language use.

These changes enhance the clarity and consistency of feedback provided by the workflows.